### PR TITLE
fixes state machine issue on PICO W

### DIFF
--- a/flash_ch32v003.py
+++ b/flash_ch32v003.py
@@ -30,12 +30,12 @@ class CH32_Flash():
         ports = [None, 7, 5, 3, 22, 20, 18]
 
         self.prog_pin = Pin(ports[pin_number], mode=Pin.IN, pull=Pin.PULL_UP)
-        self.swio_sm = rp2.StateMachine(4, singlewire_pio.singlewire_pio, freq=12_000_000,
+        self.swio_sm = rp2.StateMachine(1, singlewire_pio.singlewire_pio, freq=12_000_000,
                                         sideset_base=self.prog_pin, out_base=self.prog_pin, 
                                             set_base=self.prog_pin, in_base=self.prog_pin)
         ## Some unavoidable bit-twiddling
         ## Set side-set to control pindirs state machine
-        machine.mem32[PIO1_BASE + SM4_EXECCTRL] |= (1 << SIDE_PINDIR)
+        machine.mem32[PIO0_BASE + SM1_EXECCTRL] |= (1 << SIDE_PINDIR)
 
         ## What mode of programming we are currently engaged in.
         self.progmode = 0


### PR DESCRIPTION
When examples are run on a Supercon badge with Supercon Image, then there's an issue with the used state machine. There seems to be a conflict with state machine 4 on the RP2040W: the cyw43 WiFi module uses one state machine, apparently the first of PI1 as standard, which is coincidentally the same as was chosen for the library.